### PR TITLE
Only load numerizer if one hasn't been loaded already

### DIFF
--- a/lib/chronic_duration.rb
+++ b/lib/chronic_duration.rb
@@ -1,4 +1,4 @@
-require 'numerizer'
+require 'numerizer' unless defined?(Numerizer)
 module ChronicDuration
   extend self
   


### PR DESCRIPTION
Since Chronic isn't using the Numerizer gem and has it's own Numerizer class there are conflicts when both gems are required. By not requiring numerizer if a Numerizer class already exists we avoid the errors.
