### PR TITLE
Default units option for parse

### DIFF
--- a/lib/chronic_duration.rb
+++ b/lib/chronic_duration.rb
@@ -18,8 +18,8 @@ module ChronicDuration
   # Given a string representation of elapsed time,
   # return an integer (or float, if fractions of a
   # second are input)
-  def parse(string)
-    result = calculate_from_words(cleanup(string))
+  def parse(string, opts = {})
+    result = calculate_from_words(cleanup(string), opts)
     result == 0 ? nil : result
   end  
   
@@ -113,12 +113,12 @@ private
     res
   end
   
-  def calculate_from_words(string)
+  def calculate_from_words(string, opts)
     val = 0
     words = string.split(' ')
     words.each_with_index do |v, k|
       if v =~ float_matcher
-        val += (convert_to_number(v) * duration_units_seconds_multiplier(words[k + 1] || 'seconds'))
+        val += (convert_to_number(v) * duration_units_seconds_multiplier(words[k + 1] || (opts[:default_unit] || 'seconds')))
       end
     end
     val

--- a/spec/chronic_duration_spec.rb
+++ b/spec/chronic_duration_spec.rb
@@ -43,6 +43,10 @@ describe ChronicDuration, '.parse' do
     ChronicDuration.parse('12 mins 3 seconds').is_a?(Integer).should be_true
   end
   
+  it "should be able to parse minutes by default" do
+    ChronicDuration.parse('5', :default_unit => "minutes").should == 300
+  end
+  
   @exemplars.each do |k, v|
     it "should properly parse a duration like #{k}" do
       ChronicDuration.parse(k).should == v


### PR DESCRIPTION
I added the ability to specify the default units for parsing, like ChronicDuration.parse('5', :default_unit => "minutes").  There is a corresponding rspec test.
