### PR TITLE
Add :keep_zero option to ::parse and ::output

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -15,6 +15,10 @@ The reverse can also be accomplished with the output method.  So pass in seconds
     => true
     >> ChronicDuration.parse('4 minutes and 30 seconds')
     => 270
+    >> ChronicDuration.parse('0')
+    => nil
+    >> ChronicDuration.parse('0', :keep_zero => true)
+    => 0
     >> ChronicDuration.output(270)
     => 4 mins 30 secs
     >> ChronicDuration.output(270, :format => :short)
@@ -23,6 +27,10 @@ The reverse can also be accomplished with the output method.  So pass in seconds
     => 4 minutes 30 seconds
     >> ChronicDuration.output(270, :format => :chrono)
     => 4:30
+    >> ChronicDuration.output(0, :format => :short)
+    => nil
+    >> ChronicDuration.output(0, :format => :short, :keep_zero => true)
+    => 0s
     
 Nil is returned if the string can't be parsed
 

--- a/lib/chronic_duration.rb
+++ b/lib/chronic_duration.rb
@@ -20,7 +20,7 @@ module ChronicDuration
   # second are input)
   def parse(string, opts = {})
     result = calculate_from_words(cleanup(string), opts)
-    result == 0 ? nil : result
+    (!opts[:keep_zero] and result == 0) ? nil : result
   end  
   
   # Given an integer and an optional format,
@@ -28,6 +28,7 @@ module ChronicDuration
   def output(seconds, opts = {})
     
     opts[:format] ||= :default
+    opts[:keep_zero] ||= false
     
     years = months = days = hours = minutes = 0
     
@@ -81,7 +82,8 @@ module ChronicDuration
         # Get rid of lead off times if they are zero
         # Get rid of lead off zero
         # Get rid of trailing :
-        str.gsub(/\b\d\b/) { |d| ("%02d" % d) }.gsub(/^(00:)+/, '').gsub(/^0/, '').gsub(/:$/, '')
+        str = str.gsub(/\b\d\b/) { |d| ("%02d" % d) }.gsub(/^(00:)+/, '').gsub(/^0/, '').gsub(/:$/, '')
+        (str.empty? and opts[:keep_zero]) ? "0" : str
       end
       joiner = ''
     end
@@ -90,7 +92,9 @@ module ChronicDuration
     [:years, :months, :days, :hours, :minutes, :seconds].each do |t|
       num = eval(t.to_s)
       num = ("%.#{decimal_places}f" % num) if num.is_a?(Float) && t == :seconds 
-      result << humanize_time_unit( num, dividers[t], dividers[:pluralize], dividers[:keep_zero] )
+      keep_zero = dividers[:keep_zero]
+      keep_zero ||= opts[:keep_zero] if t == :seconds
+      result << humanize_time_unit( num, dividers[t], dividers[:pluralize], keep_zero )
     end
 
     result = result.join(joiner).squeeze(' ').strip


### PR DESCRIPTION
Since zero is not nil, and having to check for nil (or zero) everywhere is wasteful, I've added an option to allow both ChronicDuration::parse and ChronicDuration::output to return zero values.  Fixes #3.
