### PR TITLE
now prefixing with '1' if string starts with recognized word but no number, ie. 'day'

### DIFF
--- a/lib/chronic_duration.rb
+++ b/lib/chronic_duration.rb
@@ -190,6 +190,8 @@ private
         raise DurationParseError, "An invalid word #{word.inspect} was used in the string to be parsed."
       end
     end
+    # add '1' at front if string starts with something recognizable but not with a number, like 'day' or 'minute 30sec' 
+    res.unshift(1) if res.length > 0 && mappings[res[0]]  
     res.join(' ')
   end
   

--- a/spec/chronic_duration_spec.rb
+++ b/spec/chronic_duration_spec.rb
@@ -22,7 +22,9 @@ describe ChronicDuration, '.parse' do
     '3 weeks, plus 2 days' => 3600 * 24 * 7 * 3 + 3600 * 24 * 2,
     '3 weeks with 2 days' => 3600 * 24 * 7 * 3 + 3600 * 24 * 2,
     '1 month'               => 3600 * 24 * 30,
-    '2 months'              => 3600 * 24 * 30 * 2
+    '2 months'              => 3600 * 24 * 30 * 2,
+    'day'                   => 3600 * 24,
+    'minute 30s'            => 90
   }
   
   it "should return nil if the string can't be parsed" do


### PR DESCRIPTION
This is a minor improvement that makes times better readable in a DSL I'm working on (using rufus scheduler and chronic duration). This will allow all of the below

every '2 hours 30min' 
every 'day' 
every 'minute'

etc in my DSL. 
no need to require the (novice) user to specify '1 minute' instead of just 'minute'. 
Clever gem btw, I like the implementation. I added a test as well...
