### PR TITLE
Fixes #16 - Output should parse correctly 

### DIFF
--- a/lib/chronic_duration.rb
+++ b/lib/chronic_duration.rb
@@ -60,6 +60,7 @@ module ChronicDuration
           if months >= 12
             years = (months / 12).to_i
             months = (months % 12).to_i
+            days = days - (5 * years)
           end
         end
       end
@@ -71,11 +72,11 @@ module ChronicDuration
     case opts[:format]
     when :micro
       dividers = {
-        :years => 'y', :months => 'm', :weeks => 'w', :days => 'd', :hours => 'h', :minutes => 'm', :seconds => 's' }
+        :years => 'y', :months => 'mo', :weeks => 'w', :days => 'd', :hours => 'h', :minutes => 'm', :seconds => 's' }
       joiner = ''
     when :short
       dividers = {
-        :years => 'y', :months => 'm', :weeks => 'w', :days => 'd', :hours => 'h', :minutes => 'm', :seconds => 's' }
+        :years => 'y', :months => 'mo', :weeks => 'w', :days => 'd', :hours => 'h', :minutes => 'm', :seconds => 's' }
     when :default
       dividers = {
         :years => ' yr', :months => ' mo', :weeks => ' wk', :days => ' day', :hours => ' hr', :minutes => ' min', :seconds => ' sec',
@@ -170,11 +171,12 @@ private
 
   # Parse 3:41:59 and return 3 hours 41 minutes 59 seconds
   def filter_by_type(string)
+    chrono_units_list = duration_units_list.reject {|v| v == "weeks"}
     if string.gsub(' ', '') =~ /#{float_matcher}(:#{float_matcher})+/
       res = []
       string.gsub(' ', '').split(':').reverse.each_with_index do |v,k|
-        return unless duration_units_list[k]
-        res << "#{v} #{duration_units_list[k]}"
+        return unless chrono_units_list[k]
+        res << "#{v} #{chrono_units_list[k]}"
       end
       res = res.reverse.join(' ')
     else
@@ -231,11 +233,13 @@ private
       'week'    => 'weeks',
       'w'       => 'weeks',
       'months'  => 'months',
+      'mo'      => 'months',
       'mos'     => 'months',
       'month'   => 'months',
       'years'   => 'years',
       'year'    => 'years',
       'yrs'     => 'years',
+      'yr'      => 'years',
       'y'       => 'years'
     }
   end

--- a/spec/chronic_duration_spec.rb
+++ b/spec/chronic_duration_spec.rb
@@ -120,12 +120,28 @@ describe ChronicDuration, '.output' do
       },
     (6 * 30 * 24 * 3600 + 24 * 3600) =>
       {
-        :micro    => '6m1d',
-        :short    => '6m 1d',
+        :micro    => '6mo1d',
+        :short    => '6mo 1d',
         :default  => '6 mos 1 day',
         :long     => '6 months 1 day',
         :chrono   => '6:01:00:00:00' # Yuck. FIXME
-      }
+      },
+    (365 * 24 * 3600 + 24 * 3600 ) =>
+      {
+        :micro    => '1y1d',
+        :short    => '1y 1d',
+        :default  => '1 yr 1 day',
+        :long     => '1 year 1 day',
+        :chrono   => '1:00:01:00:00:00'
+      },
+    (3  * 365 * 24 * 3600 + 24 * 3600 ) =>
+      {
+        :micro    => '3y1d',
+        :short    => '3y 1d',
+        :default  => '3 yrs 1 day',
+        :long     => '3 years 1 day',
+        :chrono   => '3:00:01:00:00:00'
+      },
   }
 
   @exemplars.each do |k, v|
@@ -149,7 +165,13 @@ describe ChronicDuration, '.output' do
     ChronicDuration.output(2 * 3600 + 20 * 60).should == '2 hrs 20 mins'
   end
 
-
+  @exemplars.each do |seconds,format_spec|
+    format_spec.each do |format,_|
+      it "it should properly output a duration for #{seconds} that parses back to the same thing when using the #{format.to_s} format" do
+        ChronicDuration.parse(ChronicDuration.output(seconds, :format => format)).should == seconds
+      end
+    end
+  end
 end
 
 


### PR DESCRIPTION
Improved spec examples to include durations with
years and added a spec to cover round tripping 
durations that need to be output and then 
re-parsed, for example when populating form fields 
in a web app.
