### PR TITLE
support rufus-scheduler duration notation

### DIFF
--- a/lib/chronic_duration.rb
+++ b/lib/chronic_duration.rb
@@ -233,6 +233,7 @@ private
       'week'    => 'weeks',
       'w'       => 'weeks',
       'months'  => 'months',
+      'M'       => 'months',
       'mo'      => 'months',
       'mos'     => 'months',
       'month'   => 'months',
@@ -240,7 +241,8 @@ private
       'year'    => 'years',
       'yrs'     => 'years',
       'yr'      => 'years',
-      'y'       => 'years'
+      'y'       => 'years',
+      'Y'       => 'years'
     }
   end
 


### PR DESCRIPTION
Just added the ability to define a month with "M" and a year with "Y"
- for the M. cf. https://github.com/jmettraux/rufus-scheduler/blob/master/lib/rufus/sc/rtime.rb
- for the Y -> Y not
