### PR TITLE
Allow users to specify the duration units they want to parse/output (example: time tracker apps do not care about anything bigger than hours)

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -54,6 +54,21 @@ ChronicDuration.raise_exceptions can be set to true to raise exceptions when the
     ChronicDuration::DurationParseError: An invalid word "elephants" was used in the string to be parsed.
 
 
+ChronicDuration.use_units can be used to use only a subset of
+the supported units. For example:
+
+   >> ChronicDuration.use_units :hours, :minutes
+   >> ChronicDuration.parse('1:00')
+   => 3600
+   >> ChronicDuration.output(3600 * 48)
+   >> '48 hrs'
+
+To revert to all supported units just pass :all to use_units:
+
+   >> ChronicDuration.use_units :all
+   >> ChronicDuration.output(3600 * 48)
+   >> '2 days'
+
 == Contributors
 
 brianjlandau, jduff, olauzon, roboman, ianlevesque

--- a/spec/chronic_duration_spec.rb
+++ b/spec/chronic_duration_spec.rb
@@ -53,6 +53,28 @@ describe ChronicDuration, '.parse' do
     end
   end
 
+  context "when only hours and minutes units are enabled" do
+    before { ChronicDuration.use_units :hours, :minutes }
+    after { ChronicDuration.use_units :all }
+
+    it "should parse 4:30 as 4 hours 30 minutes" do
+      ChronicDuration.parse("4:30").should == (4 * 60 + 30) * 60
+    end
+
+    it "should ignore other units" do
+      ChronicDuration.parse("4h 30m 15s").should == (4 * 60 + 30) * 60
+    end
+
+    it "should return nil if only other units are used" do
+      ChronicDuration.parse("4s").should be_nil
+    end
+
+    it "should raise an exception if other units are used and @@raise_exceptions is true" do
+      ChronicDuration.raise_exceptions = true
+      lambda { ChronicDuration.parse('3h 15s') }.should raise_exception(ChronicDuration::DurationParseError)
+      ChronicDuration.raise_exceptions = false
+    end
+  end
 end
 
 describe ChronicDuration, '.output' do
@@ -170,6 +192,15 @@ describe ChronicDuration, '.output' do
       it "it should properly output a duration for #{seconds} that parses back to the same thing when using the #{format.to_s} format" do
         ChronicDuration.parse(ChronicDuration.output(seconds, :format => format)).should == seconds
       end
+    end
+  end
+
+  context "when only hours and minutes units are enabled" do
+    before { ChronicDuration.use_units :hours, :minutes }
+    after { ChronicDuration.use_units :all }
+
+    it "should express the output in terms of hours and minutes only" do
+      ChronicDuration.output((40 * 60 + 15) * 60).should == "40 hrs 15 mins"
     end
   end
 end


### PR DESCRIPTION
Now callers can use ChronicDuration.use_units to specify the units
they care about. Useful for example for time tracking apps which
do not care about any unit bigger than hours
