### PR TITLE
Fix inserting zero after decimal point and unnecessary zeros

### DIFF
--- a/lib/chronic_duration.rb
+++ b/lib/chronic_duration.rb
@@ -98,7 +98,7 @@ module ChronicDuration
         divider = ':'
         str.split(divider).map { |n|
           # add zeros only if n is an integer
-          n.include?('.') ? ("%.#{decimal_places}f" % n) : ("%02d" % n)
+          n.include?('.') ? ("%04.#{decimal_places}f" % n) : ("%02d" % n)
         }.join(divider).gsub(/^(00:)+/, '').gsub(/^0/, '').gsub(/:$/, '')
       end
       joiner = ''

--- a/spec/chronic_duration_spec.rb
+++ b/spec/chronic_duration_spec.rb
@@ -102,6 +102,30 @@ describe ChronicDuration, '.output' do
         :long     => '1 minute 20.1 seconds',
         :chrono   => '1:20.1'
       },
+    (60 + 0.1) =>
+      {
+        :micro    => '1m0.1s',
+        :short    => '1m 0.1s',
+        :default  => '1 min 0.1 secs',
+        :long     => '1 minute 0.1 seconds',
+        :chrono   => '1:00.1'
+      },
+    (60*60) =>
+      {
+        :micro    => '1h',
+        :short    => '1h',
+        :default  => '1 hr',
+        :long     => '1 hour',
+        :chrono   => '1:00:00'
+      },
+    (60*60 + 0.1) =>
+      {
+        :micro    => '1h0.1s',
+        :short    => '1h 0.1s',
+        :default  => '1 hr 0.1 secs',
+        :long     => '1 hour 0.1 seconds',
+        :chrono   => '1:00:00.1'
+      },
     (60 + 20.51) =>
       {
         :micro    => '1m20.51s',


### PR DESCRIPTION
- Fix issue #21 
- Fix output if seconds end with .0
- Fix output: if seconds are zero and with milliseconds then fill seconds with zeros.
