### PR TITLE
Add :keep_zero option to ::parse and ::output

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,8 +12,16 @@ The reverse can also be accomplished with the output method. So pass in seconds 
     => true
     >> ChronicDuration.parse('4 minutes and 30 seconds')
     => 270
+    >> ChronicDuration.parse('0 seconds')
+    => nil
+    >> ChronicDuration.parse('0 seconds', :keep_zero => true)
+    => 0
     >> ChronicDuration.output(270)
     => 4 mins 30 secs
+    >> ChronicDuration.output(0)
+    => nil
+    >> ChronicDuration.output(0, :keep_zero => true)
+    => 0 secs
     >> ChronicDuration.output(270, :format => :short)
     => 4m 30s
     >> ChronicDuration.output(270, :format => :long)

--- a/lib/chronic_duration.rb
+++ b/lib/chronic_duration.rb
@@ -22,7 +22,7 @@ module ChronicDuration
   # second are input)
   def parse(string, opts = {})
     result = calculate_from_words(cleanup(string), opts)
-    result == 0 ? nil : result
+    (!opts[:keep_zero] and result == 0) ? nil : result
   end
 
   # Given an integer and an optional format,
@@ -32,6 +32,7 @@ module ChronicDuration
     seconds = int if seconds - int == 0 # if seconds end with .0
 
     opts[:format] ||= :default
+    opts[:keep_zero] ||= false
 
     years = months = weeks = days = hours = minutes = 0
 
@@ -110,7 +111,9 @@ module ChronicDuration
       next if t == :weeks && !opts[:weeks]
       num = eval(t.to_s)
       num = ("%.#{decimal_places}f" % num) if num.is_a?(Float) && t == :seconds
-      humanize_time_unit( num, dividers[t], dividers[:pluralize], dividers[:keep_zero] )
+      keep_zero = dividers[:keep_zero]
+      keep_zero ||= opts[:keep_zero] if t == :seconds
+      humanize_time_unit( num, dividers[t], dividers[:pluralize], keep_zero )
     end.compact!
 
     result = result[0...opts[:units]] if opts[:units]

--- a/spec/chronic_duration_spec.rb
+++ b/spec/chronic_duration_spec.rb
@@ -31,6 +31,14 @@ describe ChronicDuration, '.parse' do
     ChronicDuration.parse('gobblygoo').should be_nil
   end
 
+  it "should return nil if the string parses as zero" do
+    ChronicDuration.parse('0').should be_nil
+  end
+
+  it "should return zero if the string parses as zero and the keep_zero option is true" do
+    ChronicDuration.parse('0', :keep_zero => true).should == 0
+  end
+
   it "should raise an exception if the string can't be parsed and @@raise_exceptions is set to true" do
     ChronicDuration.raise_exceptions = true
     lambda { ChronicDuration.parse('23 gobblygoos') }.should raise_exception(ChronicDuration::DurationParseError)
@@ -198,6 +206,33 @@ describe ChronicDuration, '.output' do
     v.each do |key, val|
       it "should properly output a duration of #{k} seconds as #{val} using the #{key.to_s} format option" do
         ChronicDuration.output(k, :format => key).should == val
+      end
+    end
+  end
+
+  @keep_zero_exemplars = {
+    (true) =>
+      {
+        :micro    => '0s',
+        :short    => '0s',
+        :default  => '0 secs',
+        :long     => '0 seconds',
+        :chrono   => '0'
+      },
+    (false) =>
+      {
+        :micro    => nil,
+        :short    => nil,
+        :default  => nil,
+        :long     => nil,
+        :chrono   => '0'
+      },
+  }
+
+  @keep_zero_exemplars.each do |k, v|
+    v.each do |key, val|
+      it "should properly output a duration of 0 seconds as #{val.nil? ? "nil" : val} using the #{key.to_s} format option, if the keep_zero option is #{k.to_s}" do
+        ChronicDuration.output(0, :format => key, :keep_zero => k).should == val
       end
     end
   end


### PR DESCRIPTION
Updated this pull as per #13

I'm not entirely happy with the `chrono` output format behaving differently to all other formats, but since that's legacy behaviour, I left it alone so as not to break existing code that expects this...

Added specs, and all existing specs passing.
