### PR TITLE
Updated to add "wks" and "wk" to parse mapping

### DIFF
--- a/lib/chronic_duration.rb
+++ b/lib/chronic_duration.rb
@@ -248,6 +248,8 @@ private
       'd'       => 'days',
       'weeks'   => 'weeks',
       'week'    => 'weeks',
+      'wks'     => 'weeks',
+      'wk'      => 'weeks',
       'w'       => 'weeks',
       'months'  => 'months',
       'mo'      => 'months',


### PR DESCRIPTION
The short and default format of weeks is currently wks when outputted. This missing mapping would cause a week outputted to be parsed as 1 second vs (3600 \* 24 \* 7) seconds when resubmitting the value to be parsed.
