### PR TITLE
allow user to specify joiner

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,8 @@ The reverse can also be accomplished with the output method. So pass in seconds 
     => 2 wks 1 day 1 hr
     >> ChronicDuration.output(1299600, :weeks => true, :units => 2)
     => 2 wks 1 day
+    >> ChronicDuration.output(1299600, :weeks => true, :units => 2, :joiner => ', ')
+    => 2 wks, 1 day
     >> ChronicDuration.output(1296000)
     => 15 days
 
@@ -65,7 +67,7 @@ Also looking for additional maintainers.
 
 ## Contributors
 
-errm,pdf, brianjlandau, jduff, olauzon, roboman, ianlevesque
+errm,pdf, brianjlandau, jduff, olauzon, roboman, ianlevesque, bolandrm
 
 ## TODO
 

--- a/lib/chronic_duration.rb
+++ b/lib/chronic_duration.rb
@@ -79,7 +79,7 @@ module ChronicDuration
       end
     end
 
-    joiner = ' '
+    joiner = opts.fetch(:joiner) { ' ' }
     process = nil
 
     case opts[:format]

--- a/spec/lib/chronic_duration_spec.rb
+++ b/spec/lib/chronic_duration_spec.rb
@@ -222,6 +222,10 @@ describe ChronicDuration do
       end
     end
 
+    it "uses user-specified joiner if provided" do
+      ChronicDuration.output(2 * 3600 + 20 * 60, joiner: ', ').should == '2 hrs, 20 mins'
+    end
+
   end
 
   describe ".filter_by_type" do


### PR DESCRIPTION
This is a pretty basic change, it simply allows a user to pass in a custom joiner string.

e.g.

```
ChronicDuration.output(1299600, :weeks => true, :units => 2, :joiner => ', ')
# => 2 wks, 1 day
```
