### PR TITLE
Handling < 1 minutes values in chrono format output

### DIFF
--- a/lib/chronic_duration.rb
+++ b/lib/chronic_duration.rb
@@ -130,7 +130,9 @@ module ChronicDuration
         str.split(divider).map { |n|
           # add zeros only if n is an integer
           n.include?('.') ? ("%04.#{decimal_places}f" % n) : ("%02d" % n)
-        }.join(divider).gsub(/^(00:)+/, '').gsub(/^0/, '').gsub(/:$/, '')
+        }.join(divider).gsub(/^(00:)+/, '').gsub(/^0/, '').gsub(/:$/, '').gsub(/^[0-9]{0,2}$/) do |i|
+          "00:%02d" % i.to_i
+        end
       end
       joiner = ''
     end

--- a/lib/chronic_duration/version.rb
+++ b/lib/chronic_duration/version.rb
@@ -1,3 +1,3 @@
 module ChronicDuration
-  VERSION = '0.10.6'
+  VERSION = '0.10.7'
 end


### PR DESCRIPTION
Because a chrono always pad the output with zero if under a minute.
