### PR TITLE
Add a `pad_to` option for the chrono format

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,8 @@ The reverse can also be accomplished with the output method. So pass in seconds 
     => 4 minutes 30 seconds
     >> ChronicDuration.output(270, :format => :chrono)
     => 4:30
+    >> ChronicDuration.output(270, :format => :chrono, :pad_to => :hours)
+    => 0:04:30
     >> ChronicDuration.output(1299600, :weeks => true)
     => 2 wks 1 day 1 hr
     >> ChronicDuration.output(1299600, :weeks => true, :units => 2)

--- a/lib/chronic_duration.rb
+++ b/lib/chronic_duration.rb
@@ -51,6 +51,7 @@ module ChronicDuration
 
     opts[:format] ||= :default
     opts[:keep_zero] ||= false
+    opts[:pad_to] ||= :seconds
 
     years = months = weeks = days = hours = minutes = 0
 
@@ -130,7 +131,11 @@ module ChronicDuration
         str.split(divider).map { |n|
           # add zeros only if n is an integer
           n.include?('.') ? ("%04.#{decimal_places}f" % n) : ("%02d" % n)
-        }.join(divider).gsub(/^(00:)+/, '').gsub(/^0/, '').gsub(/:$/, '')
+        }.join(divider).tap do |time|
+          [:years, :months, :days, :hours, :minutes, :seconds].index(opts[:pad_to]).times do
+            time.sub!(/^0+:/, '')
+          end
+        end.gsub(/^0/, '').gsub(/:$/, '')
       end
       joiner = ''
     end

--- a/spec/lib/chronic_duration_spec.rb
+++ b/spec/lib/chronic_duration_spec.rb
@@ -197,6 +197,45 @@ describe ChronicDuration do
       end
     end
 
+    @pad_to_exemplars = {
+      (:years) =>
+        {
+          :chrono => '0:00:00:00:00:00'
+        },
+      (:months) =>
+        {
+          :chrono => '0:00:00:00:00'
+        },
+      (:days) =>
+        {
+          :chrono => '0:00:00:00'
+        },
+      (:hours) =>
+        {
+          :chrono => '0:00:00'
+        },
+      (:minutes) =>
+        {
+          :chrono => '0:00'
+        },
+      (:seconds) =>
+        {
+          :chrono => '0'
+        },
+      (nil) =>
+        {
+          :chrono => '0'
+        }
+    }
+
+    @pad_to_exemplars.each do |k, v|
+      v.each do |key, val|
+        it "should properly pad durations with a #{k.nil? ? "nil" : k}-level pad_to value using the #{key.to_s} format" do
+          ChronicDuration.output(0, :format => key, :pad_to => k).should == val
+        end
+      end
+    end
+
     it "returns weeks when needed" do
       ChronicDuration.output(45*24*60*60, :weeks => true).should =~ /.*wk.*/
     end


### PR DESCRIPTION
#### Description

Allows a `pad_to` option when outputting in the chrono format.

`pad_to` can be any of `:years`, `months`, `:days`, `:hours`, `:minutes`, or `:seconds`.
When present, zeros will not be stripped for the given unit and all units below it.

e.g.

```
> ChronicDuration.output(649, :format => :chrono)
=> "10:49"
> ChronicDuration.output(649, :format => :chrono, :pad_to => :hours)
=> "0:10:49"
> ChronicDuration.output(649, :format => :chrono, :pad_to => :days)
=> "0:00:10:49"
```

My use case for this is that I'm outputting a bunch of durations in an HTML table column, and wanted the vertical edges of the times to line up with each other (+/- a character). Some are minutes long, others  hours long.
#### Code

I didn't want to refactor too much or move much around as I'm not sure how you'd prefer for that to happen, so I tried to do this in place, directly replacing the old `gsub(/^(00:)+/, '')` with this injected `tap`. As a result it can probably be considered a bit messy, so if you'd like me to clean it up let me know if there's anything I should or shouldn't move around while refactoring.
