### PR TITLE
Support 'mon' as a mapping for months

### DIFF
--- a/lib/chronic_duration.rb
+++ b/lib/chronic_duration.rb
@@ -273,6 +273,7 @@ private
       'w'       => 'weeks',
       'months'  => 'months',
       'mo'      => 'months',
+      'mon'     => 'months',
       'mos'     => 'months',
       'month'   => 'months',
       'years'   => 'years',

--- a/spec/lib/chronic_duration_spec.rb
+++ b/spec/lib/chronic_duration_spec.rb
@@ -23,6 +23,7 @@ describe ChronicDuration do
       '3 weeks and, 2 days' => 3600 * 24 * 7 * 3 + 3600 * 24 * 2,
       '3 weeks, plus 2 days' => 3600 * 24 * 7 * 3 + 3600 * 24 * 2,
       '3 weeks with 2 days' => 3600 * 24 * 7 * 3 + 3600 * 24 * 2,
+      '1mon'                  => 3600 * 24 * 30,
       '1 month'               => 3600 * 24 * 30,
       '2 months'              => 3600 * 24 * 30 * 2,
       '18 months'             => 3600 * 24 * 30 * 18,


### PR DESCRIPTION
We use this awesome gem to [translate interval strings used in Graphite](https://github.com/brutasse/graphite-api/blob/master/graphite_api/render/attime.py#L168-L183), and the only missing compatibility mapping is `mon` as `month`, which I think makes some sense.

This PR adds support for it.
