### PR TITLE
Incorrect output with chrono format

### DIFF
--- a/lib/chronic_duration.rb
+++ b/lib/chronic_duration.rb
@@ -129,7 +129,7 @@ module ChronicDuration
         divider = ':'
         str.split(divider).map { |n|
           # add zeros only if n is an integer
-          n.include?('.') ? ("%04.#{decimal_places}f" % n) : ("%02d" % n)
+          n.include?('.') ? ("%0#{decimal_places+3}.#{decimal_places}f" % n) : ("%02d" % n)
         }.join(divider).gsub(/^(00:)+/, '').gsub(/^0/, '').gsub(/:$/, '')
       end
       joiner = ''

--- a/lib/chronic_duration.rb
+++ b/lib/chronic_duration.rb
@@ -51,10 +51,12 @@ module ChronicDuration
 
     opts[:format] ||= :default
     opts[:keep_zero] ||= false
+    opts[:decimal_places] ||= seconds.to_s.split('.').last.length if seconds.is_a?(Float)
 
     years = months = weeks = days = hours = minutes = 0
 
-    decimal_places = seconds.to_s.split('.').last.length if seconds.is_a?(Float)
+    #decimal_places = seconds.to_s.split('.').last.length if seconds.is_a?(Float)
+    decimal_places = opts[:decimal_places]
 
     minute = 60
     hour = 60 * minute


### PR DESCRIPTION
Incorrect output with chrono format with second values less than 10 seconds (no print left zero)
