### PR TITLE
minor improvements

### DIFF
--- a/lib/chronic_duration.rb
+++ b/lib/chronic_duration.rb
@@ -228,7 +228,7 @@ private
   # words to defined time units
   def filter_through_white_list(string)
     res = []
-    string.split(' ').each do |word|
+    string.split(/ |-/).each do |word|
       if word =~ float_matcher
         res << word.strip
         next
@@ -238,7 +238,7 @@ private
         res << mappings[stripped_word]
       elsif !join_words.include?(stripped_word)
         raise DurationParseError, "An invalid word #{word.inspect} was used in the string to be parsed." if ChronicDuration.raise_exceptions
-        res = [] # reset the number matcher
+        res = [] if res.size == 1 # reset the number matcher if we don't have a valid duration.
       end
     end
     # add '1' at front if string starts with something recognizable but not with a number, like 'day' or 'minute 30sec'

--- a/lib/chronic_duration.rb
+++ b/lib/chronic_duration.rb
@@ -233,11 +233,12 @@ private
         res << word.strip
         next
       end
-      stripped_word = word.strip.gsub(/^,/, '').gsub(/,$/, '')
+      stripped_word = word.strip.gsub(/^,|,$|\.$/, '')
       if mappings.has_key?(stripped_word)
         res << mappings[stripped_word]
-      elsif !join_words.include?(stripped_word) and ChronicDuration.raise_exceptions
-        raise DurationParseError, "An invalid word #{word.inspect} was used in the string to be parsed."
+      elsif !join_words.include?(stripped_word)
+        raise DurationParseError, "An invalid word #{word.inspect} was used in the string to be parsed." if ChronicDuration.raise_exceptions
+        res = [] # reset the number matcher
       end
     end
     # add '1' at front if string starts with something recognizable but not with a number, like 'day' or 'minute 30sec'

--- a/lib/chronic_duration/version.rb
+++ b/lib/chronic_duration/version.rb
@@ -1,3 +1,3 @@
 module ChronicDuration
-  VERSION = '0.10.6'
+  VERSION = '0.10.7'
 end

--- a/spec/lib/chronic_duration_spec.rb
+++ b/spec/lib/chronic_duration_spec.rb
@@ -5,6 +5,7 @@ describe ChronicDuration do
   describe ".parse" do
 
     @exemplars = {
+      '5 min.'       => (60 * 5).to_i,
       '1:20'                  => 60 + 20,
       '1:20.51'               => 60 + 20.51,
       '4:01:01'               => 4 * 3600 + 60 + 1,
@@ -28,7 +29,8 @@ describe ChronicDuration do
       '18 months'             => 3600 * 24 * 30 * 18,
       '1 year 6 months'       => (3600 * 24 * (365.25 + 6 * 30)).to_i,
       'day'                   => 3600 * 24,
-      'minute 30s'            => 90
+      'minute 30s'            => 90,
+      'add 3 cups water'            => nil
     }
 
     context "when string can't be parsed" do

--- a/spec/lib/chronic_duration_spec.rb
+++ b/spec/lib/chronic_duration_spec.rb
@@ -5,6 +5,8 @@ describe ChronicDuration do
   describe ".parse" do
 
     @exemplars = {
+      "Let it sit for 60 minutes depending on your preference and time restrictions" => 60 * 60,
+      "Let it sit for 20-60 minutes depending on your preference and time restrictions" => 60 * 60,
       '5 min.'       => (60 * 5).to_i,
       '1:20'                  => 60 + 20,
       '1:20.51'               => 60 + 20.51,


### PR DESCRIPTION
- recognize units with a period following them, as they tend to be at the end of sentences or if they are abbreviated, for example "fry for 5 min."
- reset the number amount so that strings that don't contain any valid durations actually return nil, not a random number, ie parse "add 6 cups of water" as having no duration, not a duration of 6